### PR TITLE
Update uppy

### DIFF
--- a/web/app/ponthe/templates/common/layout.html
+++ b/web/app/ponthe/templates/common/layout.html
@@ -18,7 +18,7 @@
         <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,300" rel="stylesheet" type="text/css">
         <link href="https://fonts.googleapis.com/css?family=PT+Sans" type="text/css" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,300" rel="stylesheet" type="text/css">
-        <link href="https://transloadit.edgly.net/releases/uppy/v0.25.5/dist/uppy.min.css" rel="stylesheet">
+        <link href="https://releases.transloadit.com/uppy/v2.2.0/uppy.min.css" rel="stylesheet">
     </head>
 
     <body style="height: 100%;">

--- a/web/app/ponthe/templates/common/macros.html
+++ b/web/app/ponthe/templates/common/macros.html
@@ -16,7 +16,7 @@
 {%- endmacro %}
 
 {% macro uppy_script(gallery_slug, inline, trigger=None) -%}
-    <script src="https://transloadit.edgly.net/releases/uppy/v0.25.5/dist/uppy.min.js"></script>
+    <script src="https://releases.transloadit.com/uppy/v2.2.0/uppy.min.js"></script>
     <script>
         const uppyTwo = new Uppy.Core({
             debug: true,


### PR DESCRIPTION
It broke due to chrome security enhancements. File upload fails
```
Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint '<URL>'. This request has been blocked; the content must be served over HTTPS.
```

I haven't tried it locally because I have a flask version issue but the Uppy API seems to be unchanged